### PR TITLE
Enh/resque scheduler

### DIFF
--- a/roles/puma-svc/templates/app-puma@.service.d/drop-in.conf.j2
+++ b/roles/puma-svc/templates/app-puma@.service.d/drop-in.conf.j2
@@ -1,21 +1,25 @@
 # Drop in config for puma app service.
 # %i should be appname-target. e.g. umrdr-production or fishrappr-staging
-{# Require resque-pool service for apps that have it as a dependency #}
-{% if puma_svc_resque_dependency %} 
+
 [Unit]
-Requires=resque-pool@%i.service 
+{% if puma_svc_resque_dependency %}
+Requires=resque-pool@%i.service
+PropagatesReloadTo=resque-pool@%i.service
 {% endif %}
+{% if puma_svc_resque_scheduler_dependency %}
+Requires=resque-scheduler@%i.service
+PropagatesReloadTo=resque-scheduler@%i.service
+{% endif %}
+
 
 [Service]
 {% if puma_svc_resque_dependency %}
 Environment="REDIS_NS=%i"
 {% endif %}
-Environment="RBENV_ROOT={{ puma_svc_rbenv_root }}"
 
 User={{ puma_svc_app_name }}
 Group={{ puma_svc_app_name }}
 
-ExecStart={{ puma_svc_rbenv_root }}/bin/rbenv exec bundle exec puma -C config/puma.rb
 
 WorkingDirectory={{ puma_svc_deploy_dir }}/current
 PIDFile={{ puma_svc_deploy_dir }}/shared/log/{{ puma_svc_app_name }}-puma.pid

--- a/roles/puma-svc/templates/app-puma@.service.j2
+++ b/roles/puma-svc/templates/app-puma@.service.j2
@@ -4,6 +4,7 @@
 [Unit]
 Description=%i Application
 After=network.target
+
 [Service]
 Type=simple
 
@@ -12,11 +13,12 @@ Type=simple
 # Group=overridme
 # WorkingDirectory=/override/or/fail
 # PIDFile=/override/or/fail/pidfile.pid
-# ExecStart=/override/or/fail/bin/rbenv exec bundle exec puma -C config/puma.rb
-# Environment="RBENV_ROOT=/override/or/fail"
 
 # Common ruby environment config
 Environment="RAILS_ENV=production"
+Environment="RBENV_ROOT={{puma_svc_rbenv_root}}"
+ExecStart={{puma_svc_rbenv_root}}/bin/rbenv exec bundle exec puma -C config/puma.rb
+ExecReload={{puma_svc_rbenv_root}}/bin/rbenv exec bundle exec pumactl restart
 
 # Set UMASK to allow group access to application created files.
 UMask=0002

--- a/roles/puma-svc/templates/resque-pool@.service.d/drop-in.conf.j2
+++ b/roles/puma-svc/templates/resque-pool@.service.d/drop-in.conf.j2
@@ -1,8 +1,6 @@
 # Drop in configuration for resque pool service
 # %i should be appname-target e.g. umdr-staging or heliotrope-production
 [Service]
-Environment="RBENV_ROOT={{ puma_svc_rbenv_root }}"
-
 User={{ puma_svc_app_name }}
 Group={{ puma_svc_app_name }}
 

--- a/roles/puma-svc/templates/resque-scheduler@.service.j2
+++ b/roles/puma-svc/templates/resque-scheduler@.service.j2
@@ -1,8 +1,8 @@
-# Service template for resque-pool to support app-cc-puma services.
-# This template is not stand alone and instances will require a drop-in .conf file 
-# e.g. resque-pool@myapp-production.service.d/drop-in.conf
+# Service template for resque-scheduler to support app-cc-puma services.
+# This template is not stand alone and instances will require a drop-in .conf file
+# e.g. resque-scheduler@myapp-production.service.d/drop-in.conf
 [Unit]
-Description=%i Resque-Pool
+Description=%i Resque-Scheduler
 After=redis-server.service
 Requires=redis-server.service
 PartOf=app-puma@%i.service
@@ -16,17 +16,12 @@ Type=forking
 # WorkingDirectory=/override/or/fail
 # PIDFile=/override/or/fail/pidfile.pid
 # ExecStart=/override/or/fail
+# Environment="RBENV_ROOT=/override/or/fail"
 
 # Set UMASK to allow group access to application created files.
 UMask=0002
 
 Environment="RAILS_ENV=production"
-Environment="RBENV_ROOT={{puma_svc_rbenv_root}}"
-
-
-# Settings to allow resque workers to clean up after themselves.
-Environment="RUN_AT_EXIT_HOOKS=true"
-Environment="TERM_CHILD=1"
 
 # Using --hot-swap is what we ideally want, but it does not seem to be in the stable branch yet?
 #ExecStart=/usr/local/rbenv/bin/rbenv exec bundle exec resque-pool --daemon --hot-swap --environment production


### PR DESCRIPTION
- Adds an optional resque-scheduler subrole to the puma-svc role, modeled after the resque dependency. 
- Includes a sanity check that fails if resque-scheduler is required but resque is not.
