### PR TITLE
only create the target if it doesn't exist already

### DIFF
--- a/roles/target/tasks/main.yml
+++ b/roles/target/tasks/main.yml
@@ -1,3 +1,9 @@
+
+- stat:
+    path: "{{ target_deploy_path }}"
+  register: t
+
+
 - name: Create the deploy target
   file: 
     owner: "{{ target_owner }}"
@@ -5,6 +11,14 @@
     path: "{{ target_deploy_path }}"
     state: directory
     mode: "2775"
+  when: not (
+        (t.stat.exists) and
+        (t.stat.isdir) and
+        (t.stat.pw_name == "{{target_owner}}") and
+        (t.stat.gr_name == "{{target_group}}") and
+        (t.stat.mode == "2775")
+        )
+
 
 - name: Add database host alias to hosts file
   lineinfile:


### PR DESCRIPTION
In some scenarios the deployer may not be able to create the target directory, as in the case in some nfs mounted environments.  This introduces a check that allows the playbook to continue if the directory already exists and is configured the way the role would have configured it.
