### PR TITLE
Updating some things for vagrant testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,9 @@ web:
 5. provision vagrant host using:
 
 ```bash
-# Run the full playbook
-ansible-playbook playbook.predeploy.yml --private-key=.vagrant/machines/default/virtualbox/private_key -u vagrant -i inventory/vagrant --extra-vars="config_file=./vars/example-vars-staging.yml"
+# Run the vagrant provisioner to create the db_deploy_users
+playbook=playbook.vagrant.yml config_file=appname_expanded_vars.yml vagrant provision
 
-# Limit to just the tasks for the web servers
-ansible-playbook playbook.predeploy.yml --private-key=.vagrant/machines/default/virtualbox/private_key -u vagrant -i inventory/vagrant --extra-vars="config_file=./vars/example-vars-staging.yml" -l web
-
+# Run the full provisioner
+playbook=playbook.predeploy.yml config_file=appname_expanded_vars.yml vagrant provision
 ```
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "box-cutter/debian82"
+  config.vm.box = "box-cutter/debian8"
 
   # Set the VM hostname
   config.vm.hostname = "gross-hockey"
@@ -40,16 +40,22 @@ Vagrant.configure(2) do |config|
     ansible.verbose = 'v'
 
     ansible.groups = {
-      "vagrant" => ["default"]
+      "vagrant" => ["default"],
+      "web" => ["default"],
+      "app" => ["default"],
+      "db" => ["default"],
+      "solr" => ["default"]
     }
     
     # Force override of rbenv_root at command line so rbenv install puts it in the specified location
     ansible.extra_vars = {
+      ansible_shell_type: 'sh',
       rbenv_root: "/l/local/rbenv",
-      config_file: "vars/example-vars-staging.yml"
+      rbenv_group: 'root',
+      config_file: ENV['config_file'] || "vars/example-vars-staging.yml"
     }
 
-    ansible.playbook = "playbook.vagrant.yml"
+    ansible.playbook = ENV['playbook'] || "playbook.vagrant.yml"
   end
 
   # Create a private network, which allows host-only access to the machine

--- a/playbook.vagrant.yml
+++ b/playbook.vagrant.yml
@@ -7,7 +7,7 @@
     - "{{ config_file }}"
   roles:
     - role: vmock
-      vmock_deploy_users: "{{deploy_users}}"
+      vmock_deploy_users: "{{db_deploy_users}}"
       tags: ["testing", "vagrant"]
     - role: zzet.rbenv
       tags: ["testing", "vagrant"]

--- a/vars/example-vars-staging.yml
+++ b/vars/example-vars-staging.yml
@@ -5,7 +5,7 @@
 - app_user_gid:  123000
 - app_user_uid:  987000
 - deploy_root: /hydra-dev
-- deploy_users:
+- db_deploy_users:
   - alice
   - bob
   - vagrant


### PR DESCRIPTION
`vagrant up` failed when I first tried it on Ubuntu 16.04.

There were three issues:
- The box wasn't found at box-cutter.
- Ansible 2 wanted to be told the shell type.
- rbenv_group wasn't defined.

After that, provisioning failed when testing the `appname_expanded_vars.yml` file.
- The database user creation happening in `playbook.vagrant.yml` doesn't read `appname_expanded_vars.yml`

With these changes, you can do:
- `vagrant provision` normally
- `config_file=appname_expanded_vars.yml vagrant provision` to switch the `config_file` for vagrant
- `playbook=playbook.predeploy.yml config_file=appname_expanded_vars.yml vagrant provision` to test the app's vars.
