### PR TITLE
AEIM-806: provision only ssh key access to the app user

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ web:
 1. install external ansible roles `ansible-galaxy install -r dependencies.yml`
 2. install vagrant
 3. install virtual-box
-4. expand variables: `./bin/setup_ansible -v appname_vars.yml > appname_expanded_vars.yml`
+4. expand variables: `./bin/setup_ansible -v required_vars.yml > ./vars/example-vars-staging-expanded.yml`
 5. run `vagrant up` from project directory
 6. provision vagrant host using:
 
@@ -106,7 +106,9 @@ ansible-playbook playbook.predeploy.yml --private-key=.vagrant/machines/default/
 
 ```
 
-7. test setup using:
+7. deploy application (out of scope - see fauxpaas)
+
+8. test setup using:
 
 ```bash
 ansible-playbook playbook.test.yml --private-key=.vagrant/machines/default/virtualbox/private_key -u vagrant -i inventory/vagrant --extra-vars="config_file=./vars/example-vars-staging-expanded.yml"

--- a/playbook.vagrant.yml
+++ b/playbook.vagrant.yml
@@ -9,6 +9,5 @@
     - role: zzet.rbenv
       tags: ["testing", "vagrant"]
     - role: vmock
-      vmock_deploy_users: "{{user_deploy_users}}"
       tags: ["testing", "vagrant"]
 

--- a/required_vars.yml
+++ b/required_vars.yml
@@ -16,7 +16,7 @@ dependency_resque: no
 dependency_solr: yes
 dependency_resque_scheduler: no
 # Whate version of ruby does the application require?
-ruby_version: 2.3.1
+ruby_version: 2.4
 # The FQDN for the application.
 app_domain: example-staging.hydra.lib.uni.edu
 # Alternate domains for the application
@@ -39,3 +39,5 @@ solr_home: /var/lib/solr/home
 solr_core: /hydra-dev/solr/cores/demo-testing
 app_ssl_key_filename:   dev.lib.uni.edu.key
 app_ssl_crt_filename:   dev.lib.uni.edu.crt
+# public ssh key to allow for the app user
+app_ssh_key: "{{ lookup('file', '/path/to/id_rsa.pub') }}"

--- a/required_vars.yml
+++ b/required_vars.yml
@@ -5,11 +5,6 @@ app_name: demo-testing
 app_repo:  https://github.com/mlibrary/umrdr
 # Directory under which application dir will be created.
 deploy_root: /hydra-dev
-# Users allowed to deploy the application
-deploy_users:
-  - alice
-  - bob
-  - vagrant
 # Does the project require resque or solr? (yes|no)
 # Does the project require resque-scheduler?  
 dependency_resque: no

--- a/roles/db/README.md
+++ b/roles/db/README.md
@@ -3,7 +3,6 @@
 * db_name: name of the db
 * db_user_name: name of the db user
 * db_user_password: database user's **database** password
-* db_deploy_users: list of users to be granted full permissions on the db
 
 
 ## Example usage
@@ -15,6 +14,3 @@
           db_name:
           db_user_name:
           db_user_password:
-          db_deploy_users:
-            - bhock
-            - grosscol

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -17,13 +17,3 @@
     append_privs: yes
     host: "%"
     priv: "{{db_name}}.*:ALL"
-    
-- name: Grant privileges to deploy users
-  mysql_user:
-    name: "{{item}}"
-    host: "%"
-    append_privs: yes
-    priv: "{{db_name}}.*:ALL"
-  with_items: "{{db_deploy_users}}"
-
-    

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -6,6 +6,7 @@
 * user_uid: User's uid
 * user_home: User's home, which will be created.
 * user_deploy_users: list of users that will be part of this group
+* user_pubkey: Public ssh key for the user, to add to authorized_keys
 
 
 ## Example usage

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -5,7 +5,6 @@
 * user_name: User's name
 * user_uid: User's uid
 * user_home: User's home, which will be created.
-* user_deploy_users: list of users that will be part of this group
 * user_pubkey: Public ssh key for the user, to add to authorized_keys
 
 
@@ -20,6 +19,3 @@
           user_home: "/var/local/{{app_name}}"
           user_uid: 12313
           user_gid: 2923
-          user_deploy_users:
-            - bhock
-            - grosscol

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -18,14 +18,6 @@
     state: present
     system: yes
 
-- name: Add deployment users to app group
-  user:
-    name: "{{item}}"
-    append: yes
-    groups: "{{user_group}}"
-    state: present
-  with_items: "{{ user_deploy_users }}"
-
 - name: Install the user's public ssh key
   authorized_key:
     user: "{{ user_name }}"

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -26,4 +26,8 @@
     state: present
   with_items: "{{ user_deploy_users }}"
 
-
+- name: Install the user's public ssh key
+  authorized_key:
+    user: "{{ user_name }}"
+    state: present
+    key: "{{ user_ssh_key }}"

--- a/setup/db.yml
+++ b/setup/db.yml
@@ -5,4 +5,3 @@ db_user_name:
   output: (app_name[0]+app_name[1..-1].gsub(/[aeiou]/i,'')).slice(0..15)
 db_user_password:
   output: DB_USER_PASSWORD ||= `openssl rand -base64 32 | tr -dc A-Za-z0-9`
-db_deploy_users: deploy_users

--- a/setup/user.yml
+++ b/setup/user.yml
@@ -8,3 +8,4 @@ user_home:
 user_uid: app_user_uid
 user_gid: app_user_gid
 user_deploy_users: deploy_users
+user_ssh_key: app_ssh_key

--- a/setup/user.yml
+++ b/setup/user.yml
@@ -7,5 +7,4 @@ user_home:
   output: File.join("/", "var", "local", app_name)
 user_uid: app_user_uid
 user_gid: app_user_gid
-user_deploy_users: deploy_users
 user_ssh_key: app_ssh_key


### PR DESCRIPTION
See the two individual commits. One adds the ability to provision an ssh key that's authorized for the app user; the other removes all references to non-application system & database users.