### PR TITLE
AEIM-847: make cosign optional

### DIFF
--- a/required_vars.yml
+++ b/required_vars.yml
@@ -20,7 +20,9 @@ app_domain_alias:
 app_url_root: /
 # Specifically allowed IPs for the application; leave blank to allow anyone.
 app_whitelisted_ips:
-# Deny friend accounts for cosign authentication?
+# Should passive auth via cosign be enabled?
+app_use_cosign: no
+# Deny friend accounts for cosign authentication? (n/a if cosign is not in use)
 app_cosign_deny_friend: yes
 
 # Sysadmin/CoreServices provided:

--- a/roles/apache-config/templates/site.conf.j2
+++ b/roles/apache-config/templates/site.conf.j2
@@ -39,12 +39,14 @@
 
   Use logging {{apache_app_name}}
   LogLevel info
+
 {% if apache_terminate_ssl %}
   Use ssl {{apache_ssl_key}} {{apache_ssl_crt}}
 {% endif %}
 
   Use access
 
+{% if apache_use_cosign %}
   # Cosign is enabled by default.
   # Entire site is public access save for one path
   # This means the application will have to manage auth'd sessions.
@@ -61,6 +63,8 @@
 
   # Set remote user header to allow app to use http header auth.
   RequestHeader set X-Remote-User     "expr=%{REMOTE_USER}"
+{% endif %}
+
   RequestHeader set X-Forwarded-Proto 'https'
   RequestHeader unset X-Forwarded-For
   

--- a/setup/apache.yml
+++ b/setup/apache.yml
@@ -6,24 +6,40 @@ apache_app_host_priv_ip:  app_host_priv_ip
 apache_ssl_key:           app_ssl_key_filename
 apache_ssl_crt:           app_ssl_crt_filename
 
-apache_url_root:          "global=app_url_root default=/"
+apache_url_root:
+  global: app_url_root
+  default:
+
 apache_aliases:
   global:                 app_domain_aliases
   default:                []
+
 apache_whitelisted_ips:
   global:                 app_whitelisted_ips
   default:                []
-apache_log_group:         "global=apache_logs_group default=root"
-apache_cosign_deny_friend:     "global=app_cosign_deny_friend default=no"
+  
+apache_log_group:
+  global: apache_logs_group
+  default: root
+
+apache_use_cosign:
+  global: app_use_cosign
+  default: yes
+
+apache_cosign_deny_friend:
+  global: app_cosign_deny_friend
+  default: no
 
 apache_static_path:
   global: deploy_root
   output: File.join(deploy_root, app_name, "current", "public")
+
 apache_app_hostname:
   global: app_name
   output: '"app-#{app_name}"'
 
 apache_cosign_factor:     "default=UMICH.EDU"
+
 apache_terminate_ssl:
   global: apache_terminate_ssl
   default: yes


### PR DESCRIPTION
This adds a variable for cosign configuration (`app_use_cosign`) that defaults to true.

I manually tested with vagrant and ensured that:
- when `app_use_cosign=yes`, the Apache cosign configuration is included and Apache starts/has a valid config
- when `app_use_cosign=no`, the Apache cosign configuration is not included, and Apache still starts/has a valid config