### PR TITLE
AEIM-856: Validate apache config

### DIFF
--- a/roles/apache-config/defaults/main.yml
+++ b/roles/apache-config/defaults/main.yml
@@ -1,0 +1,4 @@
+apache_main_config: "/etc/apache2/apache2.conf"
+apache_log_dir: "/var/log/apache2"
+apache_sites_available: "/etc/apache2/sites-available"
+apache_sites_enabled: "/etc/apache2/sites-enabled"

--- a/roles/apache-config/handlers/main.yml
+++ b/roles/apache-config/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: reload apache
+  service: name=apache2 state=reloaded

--- a/roles/apache-config/tasks/main.yml
+++ b/roles/apache-config/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Create logging directory for appliacation
   file:
-    path: /var/log/apache2/{{apache_app_name}}
+    path: "{{apache_log_dir}}/{{apache_app_name}}"
     state: directory
     owner: root
     group: "{{apache_log_group}}"
@@ -17,14 +17,20 @@
 
 - name: Add site config to apache sites.
   template:
-    src:   site.conf.j2 
-    dest:  /etc/apache2/sites-available/{{apache_app_name}}.conf
+    src: site.conf.j2
+    dest: "{{apache_sites_available}}/{{apache_app_name}}.conf"
+    mode: 0644
     owner: root
     group: root
-    mode:  u=rw,g=r,o=r
+    # Validates apache config by appending new config to existing main
+    # configuration in a temporary file and validating that.
+    validate: "{{ lookup('template', 'validate-vhost.sh.j2') }}"
+  register: apache_config
+  notify: reload apache
 
 - name: Enable site config in apache.
   command: a2ensite {{apache_app_name}}
-
-- name: Reload apache
-  command: systemctl reload apache2
+  args:
+    creates: "{{apache_sites_enabled}}/{{apache_app_name}}.conf"
+  when: "apache_config|succeeded"
+  notify: reload apache

--- a/roles/apache-config/templates/site.conf.j2
+++ b/roles/apache-config/templates/site.conf.j2
@@ -66,6 +66,7 @@
 {% endif %}
 
   RequestHeader set X-Forwarded-Proto 'https'
+
   RequestHeader unset X-Forwarded-For
   
   Header set "Strict-Transport-Security" "max-age=3600"
@@ -106,4 +107,3 @@
 
 # Use UndefMacro directive so subsequent macros using the same name don't cause conflicts.
 UndefMacro access
-

--- a/roles/apache-config/templates/validate-vhost.sh.j2
+++ b/roles/apache-config/templates/validate-vhost.sh.j2
@@ -1,0 +1,8 @@
+bash -c 'TMPFILE=`mktemp /tmp/apache.conf.XXXXXXXXXX` && {
+  grep -v sites-enabled {{ apache_main_config }} > $TMPFILE
+  echo "Include %s" >> $TMPFILE
+  sudo apachectl -t -f $TMPFILE
+  VALID=$?
+  rm $TMPFILE
+}
+exit $VALID'


### PR DESCRIPTION
This uses bash script (included) to validate the existing apache config
(minus other enabled vhosts) with the new vhost configuration. It then
only enables the site if the configuration succeeded. This should result
in correct behavior whether or not the vhost config is already in
sites-available or sites-enabled.