### PR TITLE
AEIM-851: support custom Apache snippets

### DIFF
--- a/required_vars.yml
+++ b/required_vars.yml
@@ -38,3 +38,14 @@ app_ssl_key_filename:   dev.lib.uni.edu.key
 app_ssl_crt_filename:   dev.lib.uni.edu.crt
 # public ssh key to allow for the app user
 app_ssh_key: "{{ lookup('file', '/path/to/id_rsa.pub') }}"
+
+# Optional:
+#
+# apache_extra_config: |
+#   # Apache configuration supplied here will be appended to the end of the
+#   # generated virtual host configuration. It can include jinja2 expressions,
+#   # which will be expanded. For example:
+# 
+#   XSendFile On
+#   RequestHeader Set X-Sendfile-Type X-Sendfile
+#   XSendFilePath {{ target_deploy_path }}/current/tmp/derivatives

--- a/roles/apache-config/templates/site.conf.j2
+++ b/roles/apache-config/templates/site.conf.j2
@@ -101,11 +101,7 @@
   RewriteRule ^({{apache_url_root}}.*)$ http://{{apache_app_hostname}}:{{apache_port}}$1 [P]
   ProxyPassReverse {{apache_url_root}} http://{{apache_app_hostname}}:{{apache_port}}/
 
-{% if apache_mod_xsendfile %}
-  XSendFile On
-  RequestHeader Set X-Sendfile-Type X-Sendfile
-  XSendFilePath {{apache_derivatives_path}}
-{% endif %}
+{{ apache_extra_config }}
 
 </VirtualHost>
 

--- a/setup/apache.yml
+++ b/setup/apache.yml
@@ -5,6 +5,9 @@ apache_port:              app_port
 apache_app_host_priv_ip:  app_host_priv_ip
 apache_ssl_key:           app_ssl_key_filename
 apache_ssl_crt:           app_ssl_crt_filename
+apache_extra_config:
+  global: apache_extra_config
+  default:  ""
 
 apache_url_root:
   global: app_url_root
@@ -48,11 +51,3 @@ apache_terminate_ssl:
 apache_static_directories:
   global: apache_static_directories
   default: no
-
-apache_mod_xsendfile:
-  global: apache_mod_xsendfile
-  default: no
-
-apache_derivatives_path:
-  global: deploy_root
-  output: File.join(deploy_root, app_name, "current", "tmp", "derivatives")


### PR DESCRIPTION
Removes support for one-off "XSendFile" configuration and gives an
example of how to include that kind of support via the custom snippets.