### PR TITLE
Specify URL to solr core path

### DIFF
--- a/required_vars.yml
+++ b/required_vars.yml
@@ -2,7 +2,6 @@
 # Application pre-deployment variables file
 # 'code name' for the app (e.g. umrdr-testing, heliotrope-staging)
 app_name: demo-testing
-app_repo:  https://github.com/mlibrary/umrdr
 # Directory under which application dir will be created.
 deploy_root: /hydra-dev
 # Does the project require solr? (yes|no)
@@ -35,6 +34,7 @@ db_host_priv_ip:  "127.0.0.1"
 app_host_priv_ip: "127.0.0.1"
 solr_home: /var/lib/solr/home
 solr_core: /hydra-dev/solr/cores/demo-testing
+solr_config_svn_url:  https://github.com/mlibrary/umrdr/trunk/solr/config
 app_ssl_key_filename:   dev.lib.uni.edu.key
 app_ssl_crt_filename:   dev.lib.uni.edu.crt
 

--- a/roles/solr-core/tasks/main.yml
+++ b/roles/solr-core/tasks/main.yml
@@ -16,7 +16,7 @@
   become: no
   delegate_to: localhost
   subversion:
-    repo: "{{solr_core_repo}}/trunk/solr/config"
+    repo: "{{solr_core_svn_url}}"
     dest: "{{solr_core_tmp_path}}"
     switch: no
     force: yes

--- a/setup/solr-core.yml
+++ b/setup/solr-core.yml
@@ -10,7 +10,9 @@ solr_core_path:
 solr_core_home:
   global: solr_home
   default: unused
-solr_core_repo: app_repo
+solr_config_svn_url: 
+  global: solr_config_svn_url
+  default: unused
 solr_core_host:
   global: solr_host
   default: localhost


### PR DESCRIPTION
This allows us to specify an arbitrary URL to the solr configuration so
long as we can check it out with svn. The app repo git info is otherwise
unused in predeploy, so that info is removed.